### PR TITLE
Add more packages to gcm-filters-env

### DIFF
--- a/gcm-filters_env.yaml
+++ b/gcm-filters_env.yaml
@@ -12,3 +12,8 @@ dependencies:
   - ipykernel
   - xgcm
   - cartopy >= 0.20.0
+  - vim
+  - intake
+  - intake-xarray
+  - s3fs
+  - pooch>=1.5.0


### PR DESCRIPTION
I added a few more packages to the gcm-filters-env. With these packages, we will be able to run all the gcm-filters example notebooks from the documentation!